### PR TITLE
Don't build libtomcrypt if system-sqlcipher is on

### DIFF
--- a/qsqlcipher/qsqlcipher.pro
+++ b/qsqlcipher/qsqlcipher.pro
@@ -27,11 +27,13 @@ load(qt_plugin)
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 
-QMAKE_EXTRA_TARGETS += libtomcrypt
-win32-msvc {
-    libtomcrypt.commands = cd $$PWD/../3rdparty/libtomcrypt && \
-    nmake -f makefile.msvc CFLAGS="/Ox"
-} else {
-    libtomcrypt.commands = cd $$PWD/../3rdparty/libtomcrypt && make library CFLAGS=-fPIC
+!system-sqlcipher {
+    QMAKE_EXTRA_TARGETS += libtomcrypt
+    win32-msvc {
+        libtomcrypt.commands = cd $$PWD/../3rdparty/libtomcrypt && \
+        nmake -f makefile.msvc CFLAGS="/Ox"
+    } else {
+        libtomcrypt.commands = cd $$PWD/../3rdparty/libtomcrypt && make library CFLAGS=-fPIC
+    }
+    PRE_TARGETDEPS += libtomcrypt
 }
-PRE_TARGETDEPS += libtomcrypt


### PR DESCRIPTION
Enables building of libtomcrypt only if system-sqlcipher is not enabled.

Fixes #5 